### PR TITLE
Fix cdn url for quick

### DIFF
--- a/config/jade.js
+++ b/config/jade.js
@@ -26,7 +26,7 @@ module.exports = {
         images: imageFiles(),
         sounds: soundFiles(),
         removeFileExtension: removeFileExtension,
-        quickSrc: "https://cdn.rawgit.com/dgsprb/quick/master/releases/quick-3.0.0.js"
+        quickSrc: "https://cdn.rawgit.com/diogoschneider/quick/v4.1.0/releases/quick-3.0.0.js"
       }
     },
     files: {


### PR DESCRIPTION
This should replace the inactive URL with the new one, making it work again. Sorry for the inconvenience.